### PR TITLE
Fix profile and notes saving

### DIFF
--- a/Pipeline
+++ b/Pipeline
@@ -828,12 +828,13 @@ document.addEventListener('DOMContentLoaded', function(){
         });
     });
 
+    card.appendChild(title); card.appendChild(sub);
+    card.appendChild(expand); card.appendChild(panel);
+
+    // Enable handlers after elements are in the DOM
     enableNotesHandlers(card, String(c.id));
     enableProfileEditHandlers(card, String(c.id));
     enableCvUploadHandlers(card, String(c.id));
-
-    card.appendChild(title); card.appendChild(sub);
-    card.appendChild(expand); card.appendChild(panel);
     return card;
   }
 
@@ -879,11 +880,8 @@ document.addEventListener('DOMContentLoaded', function(){
       ajaxForm({action:'kvt_update_notes', _ajax_nonce:KVT_NONCE, id:id, notes:notes})
         .then(j=>{
           if (!j.success) return alert('No se pudo guardar.');
-          const sub = card.querySelector('.kvt-sub'); if (sub) sub.textContent = (notes ? (notes.split(/\r?\n/).filter(l=>l.trim()!=='').slice(-1)[0]||'') : '');
-          if (sub) sub.textContent = (notes ? (notes.split(/\r?\n/).filter(Boolean).slice(-1)[0]||'') : '');
-          sub.textContent = (notes ? (notes.split(/\r?\n/).filter(Boolean).slice(-1)[0]||'') : '');
-          sub.textContent = (notes ? (notes.split(/\r?\n/).filter(Boolean).slice(-1)[0]||'') : '');
-          sub.textContent = (notes ? lastNoteSnippet(notes) : '');
+          const sub = card.querySelector('.kvt-sub');
+          if (sub) sub.textContent = notes ? lastNoteSnippet(notes) : '';
           alert('Notas guardadas.');
         });
     });
@@ -1068,6 +1066,8 @@ document.addEventListener('DOMContentLoaded', function(){
           '</div>';
         }).join('');
         modalPage.textContent = 'Página '+currentPage+' de '+(pages||1);
+        if(modalPrev) modalPrev.style.display = pages>1 ? 'inline-block' : 'none';
+        if(modalNext) modalNext.style.display = pages>1 ? 'inline-block' : 'none';
         els('.kvt-mini-actions .kvt-btn', modalList).forEach(b=>{
           b.addEventListener('click', ()=>{
             const id = b.getAttribute('data-id');
@@ -1400,10 +1400,11 @@ JS;
         $page   = isset($_POST['page']) ? max(1, intval($_POST['page'])) : 1;
         $search = isset($_POST['q']) ? sanitize_text_field(trim($_POST['q'])) : '';
 
+        // Return all candidates so modal shows complete list
         $args = [
             'post_type'      => self::CPT,
             'post_status'    => 'any',
-            'posts_per_page' => 20,
+            'posts_per_page' => -1,
             'paged'          => $page,
         ];
         if ($search !== '') {


### PR DESCRIPTION
## Summary
- ensure card handlers attach after DOM insertion
- simplify note saving logic
- show all candidates in add profile modal and hide pagination when unnecessary

## Testing
- `php -l Pipeline`


------
https://chatgpt.com/codex/tasks/task_e_68b09a7c6fd8832abcf49d0e0ec16e4e