### PR TITLE
Add new-entry menu and profile assignment flow

### DIFF
--- a/Pipeline
+++ b/Pipeline
@@ -59,6 +59,12 @@ class Kovacic_Pipeline_Visualizer {
         add_action('wp_ajax_nopriv_kvt_upload_cv',     [$this, 'ajax_upload_cv']);
         add_action('wp_ajax_kvt_create_candidate',     [$this, 'ajax_create_candidate']);
         add_action('wp_ajax_nopriv_kvt_create_candidate',[$this, 'ajax_create_candidate']);
+        add_action('wp_ajax_kvt_create_client',        [$this, 'ajax_create_client']);
+        add_action('wp_ajax_nopriv_kvt_create_client', [$this, 'ajax_create_client']);
+        add_action('wp_ajax_kvt_create_process',       [$this, 'ajax_create_process']);
+        add_action('wp_ajax_nopriv_kvt_create_process',[$this, 'ajax_create_process']);
+        add_action('wp_ajax_kvt_assign_candidate',     [$this, 'ajax_assign_candidate']);
+        add_action('wp_ajax_nopriv_kvt_assign_candidate',[$this, 'ajax_assign_candidate']);
 
         // Export
         add_action('admin_post_kvt_export',          [$this, 'handle_export']);
@@ -510,7 +516,14 @@ cv_uploaded|Fecha de subida");
                 </div>
                 <div class="kvt-actions">
                     <button class="kvt-btn" id="kvt_add_profile">Añadir perfil</button>
-                    <button class="kvt-btn" id="kvt_create_candidate">Create candidate</button>
+                    <div class="kvt-new" id="kvt_new_container">
+                      <button type="button" class="kvt-btn" id="kvt_new_btn">Nuevo</button>
+                      <div class="kvt-new-menu" id="kvt_new_menu">
+                        <button type="button" data-action="candidate">Nuevo candidato</button>
+                        <button type="button" data-action="client">Nuevo cliente</button>
+                        <button type="button" data-action="process">Nuevo proceso</button>
+                      </div>
+                    </div>
                     <button class="kvt-btn kvt-secondary" id="kvt_toggle_table">Tabla</button>
                     <form id="kvt_export_form" method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" target="_blank" style="display:inline;">
                         <input type="hidden" name="action" value="kvt_export">
@@ -603,6 +616,46 @@ cv_uploaded|Fecha de subida");
             </div>
           </div>
         </div>
+        <!-- Create Client Modal -->
+        <div class="kvt-modal" id="kvt_new_client_modal" style="display:none">
+          <div class="kvt-modal-content">
+            <div class="kvt-modal-header">
+              <h3>Crear cliente</h3>
+              <button type="button" class="kvt-modal-close" id="kvt_new_client_close" aria-label="Cerrar"><span class="dashicons dashicons-no-alt"></span></button>
+            </div>
+            <div class="kvt-modal-body">
+              <div class="kvt-modal-controls">
+                <input type="text" id="kvt_client_name" placeholder="Empresa">
+                <input type="text" id="kvt_client_contact" placeholder="Persona de contacto">
+                <input type="email" id="kvt_client_email" placeholder="Email">
+                <input type="text" id="kvt_client_phone" placeholder="Teléfono">
+                <button type="button" class="kvt-btn" id="kvt_client_submit">Crear</button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Create Process Modal -->
+        <div class="kvt-modal" id="kvt_new_process_modal" style="display:none">
+          <div class="kvt-modal-content">
+            <div class="kvt-modal-header">
+              <h3>Crear proceso</h3>
+              <button type="button" class="kvt-modal-close" id="kvt_new_process_close" aria-label="Cerrar"><span class="dashicons dashicons-no-alt"></span></button>
+            </div>
+            <div class="kvt-modal-body">
+              <div class="kvt-modal-controls">
+                <input type="text" id="kvt_process_name_new" placeholder="Nombre del proceso">
+                <select id="kvt_process_client_new">
+                  <option value="">— Cliente —</option>
+                  <?php foreach ($clients as $t): ?>
+                    <option value="<?php echo esc_attr($t->term_id); ?>"><?php echo esc_html($t->name); ?></option>
+                  <?php endforeach; ?>
+                </select>
+                <button type="button" class="kvt-btn" id="kvt_process_submit">Crear</button>
+              </div>
+            </div>
+          </div>
+        </div>
 </div>
         <?php
         // Make process map available to JS BEFORE app script executes
@@ -621,8 +674,12 @@ cv_uploaded|Fecha de subida");
         .kvt-filters input,.kvt-filters select{padding:8px 10px;border:1px solid #e5e7eb;border-radius:8px}
         .kvt-btn{background:#0A212E;color:#fff;border:none;border-radius:10px;padding:10px 14px;cursor:pointer;font-weight:600}
         .kvt-btn:hover{opacity:.95}
-        .kvt-secondary{background:#475569}
-        .kvt-board{display:flex;gap:12px;overflow-x:auto;padding-bottom:6px}
+          .kvt-secondary{background:#475569}
+          .kvt-new{position:relative;display:inline-block}
+          .kvt-new-menu{position:absolute;right:0;top:100%;background:#fff;border:1px solid #e5e7eb;border-radius:8px;box-shadow:0 5px 15px rgba(0,0,0,.1);display:none;flex-direction:column;z-index:1000}
+          .kvt-new-menu button{background:none;color:#0A212E;border:none;padding:8px 12px;text-align:left;cursor:pointer}
+          .kvt-new-menu button:hover{background:#f1f5f9}
+          .kvt-board{display:flex;gap:12px;overflow-x:auto;padding-bottom:6px}
         .kvt-col{min-width:260px;background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:10px;flex:0 0 260px}
         .kvt-col h3{margin:0 0 8px;font-size:16px;color:#0A212E}
         .kvt-col.dragover{outline:2px dashed #0A212E; outline-offset: -6px;}
@@ -637,8 +694,11 @@ cv_uploaded|Fecha de subida");
         .kvt-card .kvt-panel{display:none;margin-top:8px;border-top:1px dashed #e2e8f0;padding-top:8px}
         .kvt-card .kvt-panel dl{display:grid;grid-template-columns:140px 1fr;gap:6px 10px;font-size:13px}
         .kvt-card .kvt-panel dt{font-weight:700;color:#0A212E}
-        .kvt-card .kvt-panel dd{margin:0}
-        .kvt-input{width:100%;padding:8px;border:1px solid #e5e7eb;border-radius:8px}
+          .kvt-card .kvt-panel dd{margin:0}
+          .kvt-card-head{display:flex;justify-content:space-between;align-items:center}
+          .kvt-cv-link{font-size:18px;color:#0A212E;text-decoration:none}
+          .kvt-cv-link:hover{color:#334155}
+          .kvt-input{width:100%;padding:8px;border:1px solid #e5e7eb;border-radius:8px}
         .kvt-card .kvt-notes{margin-top:8px}
         .kvt-card .kvt-notes textarea{width:100%;min-height:80px;padding:8px;border:1px solid #e5e7eb;border-radius:8px}
         .kvt-card .kvt-notes .row{display:flex;gap:8px;margin-top:6px;flex-wrap:wrap}
@@ -661,8 +721,9 @@ cv_uploaded|Fecha de subida");
         .kvt-modal-controls select,.kvt-modal-controls input{padding:8px 10px;border:1px solid #e5e7eb;border-radius:8px}
         .kvt-modal-list{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:10px;max-height:420px;overflow:auto}
         .kvt-card-mini{border:1px solid #e5e7eb;border-radius:10px;padding:10px}
-        .kvt-card-mini h4{margin:0 0 6px}
-        .kvt-mini-actions{display:flex;gap:8px;margin-top:8px}
+          .kvt-card-mini h4{margin:0 0 6px}
+          .kvt-mini-panel{display:none;margin-top:8px;border-top:1px dashed #e2e8f0;padding-top:8px}
+          .kvt-mini-actions{display:flex;gap:8px;margin-top:8px}
         .kvt-modal-pager{display:flex;gap:10px;align-items:center;justify-content:flex-end;margin-top:10px}
         ";
         wp_register_style('kvt-style', false);
@@ -702,9 +763,11 @@ document.addEventListener('DOMContentLoaded', function(){
   const inpSearch  = el('#kvt_search');
   const btnRefresh = el('#kvt_refresh');
   const btnToggle  = el('#kvt_toggle_table');
-  const btnCSV     = el('#kvt_export_csv');
-  const btnXLS     = el('#kvt_export_xls');
-  const btnAdd     = el('#kvt_add_profile');
+    const btnCSV     = el('#kvt_export_csv');
+    const btnXLS     = el('#kvt_export_xls');
+    const btnAdd     = el('#kvt_add_profile');
+    const btnNew     = el('#kvt_new_btn');
+    const newMenu    = el('#kvt_new_menu');
 
   const modal      = el('#kvt_modal');
   const modalClose = el('.kvt-modal-close', modal);
@@ -789,16 +852,25 @@ document.addEventListener('DOMContentLoaded', function(){
     return slice + (words.length>10 ? '…' : '');
   }
 
-  function cardTemplate(c){
-    const card = document.createElement('div');
-    card.className = 'kvt-card'; card.setAttribute('draggable','true'); card.dataset.id = c.id;
+    function cardTemplate(c){
+      const card = document.createElement('div');
+      card.className = 'kvt-card'; card.setAttribute('draggable','true'); card.dataset.id = c.id;
 
-    const title = document.createElement('p'); title.className = 'kvt-title';
-    title.textContent = (c.meta.first_name||'') + ' ' + (c.meta.last_name||'');
-    if (title.textContent.trim()==='') title.textContent = c.title;
+      const head = document.createElement('div'); head.className='kvt-card-head';
+      const title = document.createElement('p'); title.className = 'kvt-title';
+      title.textContent = (c.meta.first_name||'') + ' ' + (c.meta.last_name||'');
+      if (title.textContent.trim()==='') title.textContent = c.title;
+      head.appendChild(title);
+      if (c.meta.cv_url){
+        const cv = document.createElement('a');
+        cv.href = c.meta.cv_url; cv.target='_blank';
+        cv.className = 'kvt-cv-link dashicons dashicons-media-document';
+        cv.setAttribute('title','Ver CV');
+        head.appendChild(cv);
+      }
 
-    const sub = document.createElement('p'); sub.className = 'kvt-sub';
-    sub.textContent = lastNoteSnippet(c.meta.notes);
+      const sub = document.createElement('p'); sub.className = 'kvt-sub';
+      sub.textContent = lastNoteSnippet(c.meta.notes);
 
     const expand = document.createElement('div'); expand.className='kvt-expand';
     const btn = document.createElement('button'); btn.type='button'; btn.textContent='Ver perfil';
@@ -828,7 +900,7 @@ document.addEventListener('DOMContentLoaded', function(){
         });
     });
 
-    card.appendChild(title); card.appendChild(sub);
+      card.appendChild(head); card.appendChild(sub);
     card.appendChild(expand); card.appendChild(panel);
 
     // Enable handlers after elements are in the DOM
@@ -1055,39 +1127,50 @@ document.addEventListener('DOMContentLoaded', function(){
       .then(j=>{
         if(!j.success) return alert('No se pudo cargar la lista.');
         const {items,pages} = j.data;
-        modalList.innerHTML = items.map(it=>{
-          const m = it.meta||{};
-          return '<div class="kvt-card-mini">'+
-            '<h4>'+esc((m.first_name||'')+' '+(m.last_name||''))+'</h4>'+
-            '<p style="margin:.2em 0;color:#64748b">'+esc(m.email||'')+'</p>'+
-            '<div class="kvt-mini-actions">'+
-              '<button type="button" class="kvt-btn" data-id="'+it.id+'">Duplicar</button>'+
-            '</div>'+
-          '</div>';
-        }).join('');
-        modalPage.textContent = 'Página '+currentPage+' de '+(pages||1);
-        if(modalPrev) modalPrev.style.display = pages>1 ? 'inline-block' : 'none';
-        if(modalNext) modalNext.style.display = pages>1 ? 'inline-block' : 'none';
-        els('.kvt-mini-actions .kvt-btn', modalList).forEach(b=>{
-          b.addEventListener('click', ()=>{
-            const id = b.getAttribute('data-id');
-            const proc = modalProc.value;
-            const cli  = modalCli.value;
-            const p = new URLSearchParams();
-            p.set('action','kvt_clone_profile');
-            p.set('_ajax_nonce', KVT_NONCE);
-            p.set('source_id', id);
-            p.set('process_id', proc);
-            p.set('client_id', cli);
-            fetch(KVT_AJAX,{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:p.toString()})
-              .then(r=>r.json()).then(j=>{
-                if(!j.success) return alert(j.data && j.data.msg ? j.data.msg : 'No se pudo crear.');
-                alert('Perfil creado (#'+j.data.id+').');
-                closeModal();
-                refresh();
-              });
+          modalList.innerHTML = items.map(it=>{
+            const m = it.meta||{};
+            return '<div class="kvt-card-mini" data-id="'+it.id+'">'+
+              '<h4>'+esc((m.first_name||'')+' '+(m.last_name||''))+'</h4>'+
+              '<p style="margin:.2em 0;color:#64748b">'+esc(m.email||'')+'</p>'+
+              '<div class="kvt-mini-actions">'+
+                '<button type="button" class="kvt-btn kvt-mini-add" data-id="'+it.id+'">Añadir</button>'+
+                '<button type="button" class="kvt-btn kvt-secondary kvt-mini-view" data-id="'+it.id+'">Ver perfil</button>'+
+              '</div>'+
+              '<div class="kvt-mini-panel">'+buildProfileHTML({meta:it.meta})+'</div>'+
+            '</div>';
+          }).join('');
+          modalPage.textContent = 'Página '+currentPage+' de '+(pages||1);
+          if(modalPrev) modalPrev.style.display = pages>1 ? 'inline-block' : 'none';
+          if(modalNext) modalNext.style.display = pages>1 ? 'inline-block' : 'none';
+          els('.kvt-mini-add', modalList).forEach(b=>{
+            b.addEventListener('click', ()=>{
+              const id = b.getAttribute('data-id');
+              const proc = modalProc.value;
+              const cli  = modalCli.value;
+              const p = new URLSearchParams();
+              p.set('action','kvt_assign_candidate');
+              p.set('_ajax_nonce', KVT_NONCE);
+              p.set('candidate_id', id);
+              p.set('process_id', proc);
+              p.set('client_id', cli);
+              fetch(KVT_AJAX,{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:p.toString()})
+                .then(r=>r.json()).then(j=>{
+                  if(!j.success) return alert(j.data && j.data.msg ? j.data.msg : 'No se pudo asignar.');
+                  alert('Candidato asignado.');
+                  closeModal();
+                  refresh();
+                });
+            });
           });
-        });
+          els('.kvt-mini-view', modalList).forEach(b=>{
+            b.addEventListener('click', ()=>{
+              const card = b.closest('.kvt-card-mini');
+              const panel = card.querySelector('.kvt-mini-panel');
+              const show = panel.style.display==='block';
+              panel.style.display = show?'none':'block';
+              b.textContent = show?'Ver perfil':'Ocultar';
+            });
+          });
       });
   }
   modalPrev && modalPrev.addEventListener('click', ()=>{ if(currentPage>1) listProfiles(currentPage-1); });
@@ -1110,8 +1193,7 @@ document.addEventListener('DOMContentLoaded', function(){
   modalSearch && modalSearch.addEventListener('input', ()=>{ clearTimeout(mto); mto=setTimeout(()=>listProfiles(1), 300); });
   btnAdd && btnAdd.addEventListener('click', openModal);
   // Create candidate modal
-  const btnCreate = el('#kvt_create_candidate');
-  const cmodal = el('#kvt_create_modal');
+    const cmodal = el('#kvt_create_modal');
   const cclose = el('#kvt_create_close');
   const cfirst = el('#kvt_new_first');
   const clast  = el('#kvt_new_last');
@@ -1138,7 +1220,6 @@ document.addEventListener('DOMContentLoaded', function(){
     cmodal.style.display = 'flex';
   }
   function closeCModal(){ cmodal.style.display='none'; }
-  btnCreate && btnCreate.addEventListener('click', openCModal);
   cclose && cclose.addEventListener('click', closeCModal);
   cmodal && cmodal.addEventListener('click', (e)=>{ if(e.target===cmodal) closeCModal(); });
   ccli && ccli.addEventListener('change', ()=>{
@@ -1147,7 +1228,7 @@ document.addEventListener('DOMContentLoaded', function(){
     cproc.innerHTML = '<option value=\"\">— Proceso —</option>';
     window.KVT_PROCESS_MAP.forEach(p=>{ if(!cid || p.client_id===cid){ const o=document.createElement('option'); o.value=String(p.id); o.textContent=p.name; cproc.appendChild(o);} });
   });
-  csubmit && csubmit.addEventListener('click', ()=>{
+    csubmit && csubmit.addEventListener('click', ()=>{
     const params = new URLSearchParams();
     params.set('action','kvt_create_candidate');
     params.set('_ajax_nonce', KVT_NONCE);
@@ -1162,7 +1243,72 @@ document.addEventListener('DOMContentLoaded', function(){
         alert('Candidato creado (#'+j.data.id+').');
         closeCModal(); refresh();
       });
-  });
+    });
+
+    // Create client modal
+    const clmodal = el('#kvt_new_client_modal');
+    const clclose = el('#kvt_new_client_close');
+    const clname  = el('#kvt_client_name');
+    const clcont  = el('#kvt_client_contact');
+    const clemail = el('#kvt_client_email');
+    const clphone = el('#kvt_client_phone');
+    const clsubmit= el('#kvt_client_submit');
+    function openClModal(){ clname.value=''; clcont.value=''; clemail.value=''; clphone.value=''; clmodal.style.display='flex'; }
+    function closeClModal(){ clmodal.style.display='none'; }
+    clclose && clclose.addEventListener('click', closeClModal);
+    clmodal && clmodal.addEventListener('click', e=>{ if(e.target===clmodal) closeClModal(); });
+    clsubmit && clsubmit.addEventListener('click', ()=>{
+      const params = new URLSearchParams();
+      params.set('action','kvt_create_client');
+      params.set('_ajax_nonce', KVT_NONCE);
+      params.set('name', clname.value||'');
+      params.set('contact_name', clcont.value||'');
+      params.set('contact_email', clemail.value||'');
+      params.set('contact_phone', clphone.value||'');
+      fetch(KVT_AJAX,{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:params.toString()})
+        .then(r=>r.json()).then(j=>{
+          if(!j.success) return alert(j.data && j.data.msg ? j.data.msg : 'No se pudo crear.');
+          alert('Cliente creado (#'+j.data.id+').');
+          closeClModal(); location.reload();
+        });
+    });
+
+    // Create process modal
+    const pmodal = el('#kvt_new_process_modal');
+    const pclose = el('#kvt_new_process_close');
+    const pname  = el('#kvt_process_name_new');
+    const pcli   = el('#kvt_process_client_new');
+    const psubmit= el('#kvt_process_submit');
+    function openPModal(){ pname.value=''; pmodal.style.display='flex'; }
+    function closePModal(){ pmodal.style.display='none'; }
+    pclose && pclose.addEventListener('click', closePModal);
+    pmodal && pmodal.addEventListener('click', e=>{ if(e.target===pmodal) closePModal(); });
+    psubmit && psubmit.addEventListener('click', ()=>{
+      const params = new URLSearchParams();
+      params.set('action','kvt_create_process');
+      params.set('_ajax_nonce', KVT_NONCE);
+      params.set('name', pname.value||'');
+      params.set('client_id', pcli.value||'');
+      fetch(KVT_AJAX,{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:params.toString()})
+        .then(r=>r.json()).then(j=>{
+          if(!j.success) return alert(j.data && j.data.msg ? j.data.msg : 'No se pudo crear.');
+          alert('Proceso creado (#'+j.data.id+').');
+          closePModal(); location.reload();
+        });
+    });
+
+    // Nuevo menu actions
+    btnNew && btnNew.addEventListener('click', ()=>{ newMenu.style.display = newMenu.style.display==='flex' ? 'none' : 'flex'; });
+    document.addEventListener('click', e=>{ if(!btnNew.contains(e.target) && !newMenu.contains(e.target)) newMenu.style.display='none'; });
+    els('#kvt_new_menu button').forEach(b=>{
+      b.addEventListener('click', ()=>{
+        const act = b.dataset.action;
+        newMenu.style.display='none';
+        if(act==='candidate') openCModal();
+        if(act==='client') openClModal();
+        if(act==='process') openPModal();
+      });
+    });
 
   // Easier drag & drop: allow drop anywhere in column and highlight
   els('.kvt-col').forEach(col=>{
@@ -1520,11 +1666,65 @@ JS;
         if ($client_id) wp_set_object_terms($new_id, [$client_id], self::TAX_CLIENT, false);
         if ($process_id) wp_set_object_terms($new_id, [$process_id], self::TAX_PROCESS, false);
 
-        wp_send_json_success(['id'=>$new_id]);
-    }
+      wp_send_json_success(['id'=>$new_id]);
+      }
 
-    /* Export */
-    public function handle_export() {
+      public function ajax_create_client() {
+          check_ajax_referer('kvt_nonce');
+
+          $name  = isset($_POST['name']) ? sanitize_text_field($_POST['name']) : '';
+          $cname = isset($_POST['contact_name'])  ? sanitize_text_field($_POST['contact_name'])  : '';
+          $cemail= isset($_POST['contact_email']) ? sanitize_email($_POST['contact_email'])      : '';
+          $cphone= isset($_POST['contact_phone']) ? sanitize_text_field($_POST['contact_phone']) : '';
+
+          if ($name === '') wp_send_json_error(['msg'=>'Nombre requerido'],400);
+
+          $term = wp_insert_term($name, self::TAX_CLIENT);
+          if (is_wp_error($term)) wp_send_json_error(['msg'=>$term->get_error_message()],500);
+          $tid = (int) $term['term_id'];
+          update_term_meta($tid, 'contact_name', $cname);
+          update_term_meta($tid, 'contact_email', $cemail);
+          update_term_meta($tid, 'contact_phone', $cphone);
+
+          wp_send_json_success(['id'=>$tid]);
+      }
+
+      public function ajax_create_process() {
+          check_ajax_referer('kvt_nonce');
+
+          $name = isset($_POST['name']) ? sanitize_text_field($_POST['name']) : '';
+          $client_id = isset($_POST['client_id']) ? intval($_POST['client_id']) : 0;
+          if ($name === '') wp_send_json_error(['msg'=>'Nombre requerido'],400);
+
+          $term = wp_insert_term($name, self::TAX_PROCESS);
+          if (is_wp_error($term)) wp_send_json_error(['msg'=>$term->get_error_message()],500);
+          $tid = (int) $term['term_id'];
+          if ($client_id) update_term_meta($tid, 'kvt_process_client', $client_id);
+
+          wp_send_json_success(['id'=>$tid]);
+      }
+
+      public function ajax_assign_candidate() {
+          check_ajax_referer('kvt_nonce');
+
+          $id        = isset($_POST['candidate_id']) ? intval($_POST['candidate_id']) : 0;
+          $client_id = isset($_POST['client_id']) ? intval($_POST['client_id']) : 0;
+          $process_id= isset($_POST['process_id']) ? intval($_POST['process_id']) : 0;
+
+          if (!$id || get_post_type($id) !== self::CPT) {
+              wp_send_json_error(['msg'=>'Invalid candidate'],400);
+          }
+          if ($process_id && has_term($process_id, self::TAX_PROCESS, $id)) {
+              wp_send_json_error(['msg'=>'Ya asignado'],400);
+          }
+          if ($client_id) wp_set_object_terms($id, [$client_id], self::TAX_CLIENT, true);
+          if ($process_id) wp_set_object_terms($id, [$process_id], self::TAX_PROCESS, true);
+
+          wp_send_json_success(['id'=>$id]);
+      }
+
+      /* Export */
+      public function handle_export() {
         if (!is_user_logged_in() || !current_user_can('edit_posts')) wp_die('Unauthorized');
         check_admin_referer('kvt_export','kvt_export_nonce');
 


### PR DESCRIPTION
## Summary
- Replace "Create candidate" button with "Nuevo" menu to add candidates, clients or processes
- Allow assigning existing candidates without duplication and view their full profile before adding
- Show CV link icon on candidate cards and support new client/process creation

## Testing
- `php -l Pipeline`

------
https://chatgpt.com/codex/tasks/task_e_68b09f1d183c832aa84b152091c28ee7