### PR TITLE
Improve tag handling and candidate search

### DIFF
--- a/Pipeline
+++ b/Pipeline
@@ -43,10 +43,6 @@ class Kovacic_Pipeline_Visualizer {
         add_action('wp_ajax_nopriv_kvt_get_candidates',[$this, 'ajax_get_candidates']);
         add_action('wp_ajax_kvt_update_status',        [$this, 'ajax_update_status']);
         add_action('wp_ajax_nopriv_kvt_update_status', [$this, 'ajax_update_status']);
-        add_action('wp_ajax_kvt_update_notes',         [$this, 'ajax_update_notes']);
-        add_action('wp_ajax_nopriv_kvt_update_notes',  [$this, 'ajax_update_notes']);
-        add_action('wp_ajax_kvt_delete_notes',         [$this, 'ajax_delete_notes']);
-        add_action('wp_ajax_nopriv_kvt_delete_notes',  [$this, 'ajax_delete_notes']);
         add_action('wp_ajax_kvt_delete_candidate',     [$this, 'ajax_delete_candidate']);
         add_action('wp_ajax_nopriv_kvt_delete_candidate',[$this, 'ajax_delete_candidate']);
         add_action('wp_ajax_kvt_update_profile',       [$this, 'ajax_update_profile']);
@@ -244,7 +240,7 @@ cv_uploaded|Fecha de subida");
             $vv = get_post_meta($post_id, $fb, true);
             if ($vv !== '' && $vv !== null) return $vv;
         }
-        return '';
+    return '<dl>'+dl+'</dl>'+notes;
     }
     private function fmt_date_ddmmyyyy($val){
         $val = trim((string)$val);
@@ -703,8 +699,9 @@ cv_uploaded|Fecha de subida");
         .kvt-card.dragging{opacity:.6}
         .kvt-card .kvt-title{font-weight:700;margin:0 0 4px}
         .kvt-card .kvt-sub{font-size:12px;color:#64748b;margin:0}
-        .kvt-card .kvt-tags{margin:4px 0;display:flex;gap:4px;flex-wrap:wrap}
-        .kvt-card .kvt-tag{background:#eef2f7;color:#0A212E;border:1px solid #e5e7eb;border-radius:6px;padding:2px 6px;font-size:12px}
+        .kvt-tags{margin:4px 0;display:flex;gap:4px;flex-wrap:wrap}
+        .kvt-tag{background:#eef2f7;color:#0A212E;border:1px solid #e5e7eb;border-radius:6px;padding:2px 6px;font-size:12px;pointer-events:none}
+        .kvt-tag.kvt-tag-sm{padding:1px 5px;font-size:11px}
         .kvt-card .kvt-meta{display:none}
         .kvt-card .kvt-expand{margin-top:8px;display:flex;gap:8px;flex-wrap:wrap}
         .kvt-card .kvt-expand button{background:#eef2f7;color:#0A212E;border:1px solid #e5e7eb;border-radius:8px;padding:6px 10px;cursor:pointer;font-weight:600}
@@ -718,9 +715,8 @@ cv_uploaded|Fecha de subida");
           .kvt-input{width:100%;padding:8px;border:1px solid #e5e7eb;border-radius:8px}
         .kvt-card .kvt-notes{margin-top:8px}
         .kvt-card .kvt-notes textarea{width:100%;min-height:80px;padding:8px;border:1px solid #e5e7eb;border-radius:8px}
-        .kvt-card .kvt-notes .row{display:flex;gap:8px;margin-top:6px;flex-wrap:wrap}
-        .kvt-card .kvt-notes .row button{padding:8px 10px;border-radius:8px;border:1px solid #e5e7eb;background:#0A212E;color:#fff;cursor:pointer}
-        .kvt-card .kvt-notes .row button.kvt-danger{background:#b91c1c}
+        .kvt-card .kvt-actions{display:flex;gap:8px;margin-top:6px;flex-wrap:wrap}
+        .kvt-card .kvt-actions button{padding:8px 10px;border-radius:8px;border:1px solid #e5e7eb;background:#0A212E;color:#fff;cursor:pointer}
         .kvt-empty{padding:16px;color:#475569;font-style:italic}
         .kvt-delete{background:none !important;border:none !important;color:#b91c1c !important;font-size:18px;line-height:1;cursor:pointer;padding:0}
         .kvt-delete:hover{color:#7f1d1d !important}
@@ -902,8 +898,7 @@ document.addEventListener('DOMContentLoaded', function(){
       const tagsWrap = document.createElement('div'); tagsWrap.className = 'kvt-tags';
       if (c.meta && c.meta.tags){
         c.meta.tags.split(',').map(t=>t.trim()).filter(Boolean).forEach(t=>{
-          const span = document.createElement('button');
-          span.type = 'button';
+          const span = document.createElement('span');
           span.className = 'kvt-tag';
           span.textContent = t;
           tagsWrap.appendChild(span);
@@ -948,7 +943,6 @@ document.addEventListener('DOMContentLoaded', function(){
     card.appendChild(expand); card.appendChild(panel);
 
     // Enable handlers after elements are in the DOM
-    enableNotesHandlers(card, String(c.id));
     enableProfileEditHandlers(card, String(c.id));
     enableCvUploadHandlers(card, String(c.id));
     return card;
@@ -966,7 +960,10 @@ document.addEventListener('DOMContentLoaded', function(){
       kvInp('Teléfono',     input((m.phone||''))) +
       kvInp('País',         input((m.country||''))) +
       kvInp('Ciudad',       input((m.city||''))) +
-      kvInp('Tags',         input((m.tags||''))) +
+      kvInp('Tags',         input((m.tags||''), 'text', 'tag1, tag2') +
+                            '<div class=\\"kvt-tags kvt-tags-preview\\">'+
+                            (m.tags||'').split(',').map(t=>'<span class=\\"kvt-tag kvt-tag-sm\\">'+esc(t.trim())+'</span>').join('')+
+                            '</div><small>Separe las etiquetas con coma (,)</small>') +
       kvInp('CV (URL)',     input((m.cv_url||''), 'url', 'https://...')) +
       kvInp('Subir CV',     '<input class=\"kvt-input kvt-cv-file\" type=\"file\" accept=\".pdf,.doc,.docx,application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document\">'+
                             '<button type=\"button\" class=\"kvt-upload-cv\" style=\"margin-top:6px\">Subir y guardar</button>') +
@@ -977,35 +974,33 @@ document.addEventListener('DOMContentLoaded', function(){
       '<div class="kvt-notes">'+
         '<label><strong>Notas</strong></label>'+
         '<textarea class="kvt-notes-text">'+esc(notesVal)+'</textarea>'+
-        '<div class="row">'+
-          '<button type="button" class="kvt-delete-notes kvt-danger">Borrar notas</button>'+
-          '<button type="button" class="kvt-save-profile">Guardar perfil</button>'+
-        '</div>'+
+      '</div>'+
+      '<div class="kvt-actions">'+
+        '<button type="button" class="kvt-save-profile">Guardar perfil</button>'+
       '</div>';
 
     return '<dl>'+dl+'</dl>'+notes;
   }
 
-  function enableNotesHandlers(card, id){
-    const txt = card.querySelector('.kvt-notes-text');
-    const btnDel  = card.querySelector('.kvt-delete-notes');
-
-    btnDel && btnDel.addEventListener('click', ()=>{
-      if (!confirm('¿Seguro que deseas borrar todas las notas?')) return;
-      ajaxForm({action:'kvt_delete_notes', _ajax_nonce:KVT_NONCE, id:id})
-        .then(j=>{
-          if (!j.success) return alert('No se pudo borrar.');
-          if (txt) txt.value = '';
-          const sub = card.querySelector('.kvt-sub'); if (sub) sub.textContent = '';
-          alert('Notas borradas.');
-        });
-    });
-  }
 
   function enableProfileEditHandlers(card, id){
     const inputs = card.querySelectorAll('dl .kvt-input');
     const txtNotes = card.querySelector('.kvt-notes-text');
     const btnSaveProfile = card.querySelector('.kvt-save-profile');
+    const tagInput = inputs[6];
+    const tagPreview = card.querySelector('.kvt-tags-preview');
+    if (tagInput && tagPreview){
+      const upd = ()=>{
+        tagPreview.innerHTML='';
+        tagInput.value.split(',').map(t=>t.trim()).filter(Boolean).forEach(t=>{
+          const s=document.createElement('span');
+          s.className='kvt-tag kvt-tag-sm';
+          s.textContent=t;
+          tagPreview.appendChild(s);
+        });
+      };
+      tagInput.addEventListener('input', upd);
+    }
     if (!btnSaveProfile) return;
 
     btnSaveProfile.addEventListener('click', ()=>{
@@ -1034,8 +1029,7 @@ document.addEventListener('DOMContentLoaded', function(){
             tagWrap.innerHTML = '';
             if (payload.tags){
               payload.tags.split(',').map(t=>t.trim()).filter(Boolean).forEach(t=>{
-                const span = document.createElement('button');
-                span.type = 'button';
+                const span = document.createElement('span');
                 span.className = 'kvt-tag';
                 span.textContent = t;
                 tagWrap.appendChild(span);
@@ -1211,9 +1205,10 @@ document.addEventListener('DOMContentLoaded', function(){
         const {items,pages} = j.data;
           modalList.innerHTML = items.map(it=>{
             const m = it.meta||{};
+            const tagHtml = m.tags ? '<div class="kvt-tags">'+m.tags.split(',').map(t=>'<span class="kvt-tag kvt-tag-sm">'+esc(t.trim())+'</span>').join('')+'</div>' : '';
             return '<div class="kvt-card-mini" data-id="'+it.id+'">'+
               '<h4>'+esc((m.first_name||'')+' '+(m.last_name||''))+(m.cv_url?'<a href="'+escAttr(m.cv_url)+'" class="kvt-cv-link dashicons dashicons-media-document" target="_blank" title="Ver CV"></a>':'')+'</h4>'+
-              '<p style="margin:.2em 0;color:#64748b">'+esc(m.email||'')+'</p>'+
+              tagHtml+
               '<div class="kvt-mini-actions">'+
                 '<button type="button" class="kvt-btn kvt-mini-add" data-id="'+it.id+'">Añadir</button>'+
                 '<button type="button" class="kvt-btn kvt-secondary kvt-mini-view" data-id="'+it.id+'">Ver perfil</button>'+
@@ -1256,7 +1251,6 @@ document.addEventListener('DOMContentLoaded', function(){
           items.forEach(it=>{
             const card = modalList.querySelector('.kvt-card-mini[data-id="'+it.id+'"]');
             if(card){
-              enableNotesHandlers(card, String(it.id));
               enableProfileEditHandlers(card, String(it.id));
               enableCvUploadHandlers(card, String(it.id));
             }
@@ -1487,10 +1481,16 @@ JS;
                 ['key'=>'kvt_first_name','value'=>$search,'compare'=>'LIKE'],
                 ['key'=>'kvt_last_name', 'value'=>$search,'compare'=>'LIKE'],
                 ['key'=>'kvt_email',     'value'=>$search,'compare'=>'LIKE'],
+                ['key'=>'kvt_phone',     'value'=>$search,'compare'=>'LIKE'],
+                ['key'=>'kvt_country',   'value'=>$search,'compare'=>'LIKE'],
+                ['key'=>'kvt_city',      'value'=>$search,'compare'=>'LIKE'],
                 ['key'=>'kvt_tags',      'value'=>$search,'compare'=>'LIKE'],
                 ['key'=>'first_name','value'=>$search,'compare'=>'LIKE'],
                 ['key'=>'last_name', 'value'=>$search,'compare'=>'LIKE'],
                 ['key'=>'email',     'value'=>$search,'compare'=>'LIKE'],
+                ['key'=>'phone',     'value'=>$search,'compare'=>'LIKE'],
+                ['key'=>'country',   'value'=>$search,'compare'=>'LIKE'],
+                ['key'=>'city',      'value'=>$search,'compare'=>'LIKE'],
                 ['key'=>'tags',      'value'=>$search,'compare'=>'LIKE'],
             ];
             $args['s'] = $search;
@@ -1535,25 +1535,6 @@ JS;
             wp_send_json_error(['msg'=>'Invalid'], 400);
         }
         update_post_meta($id, 'kvt_status', $st);
-        wp_send_json_success(['ok'=>true]);
-    }
-
-    public function ajax_update_notes() {
-        check_ajax_referer('kvt_nonce');
-        $id = isset($_POST['id']) ? intval($_POST['id']) : 0;
-        $notes = isset($_POST['notes']) ? wp_kses_post($_POST['notes']) : '';
-        if (!$id) wp_send_json_error(['msg'=>'Invalid'], 400);
-        update_post_meta($id, 'kvt_notes', $notes);
-        update_post_meta($id, 'notes', $notes);
-        wp_send_json_success(['ok'=>true]);
-    }
-
-    public function ajax_delete_notes() {
-        check_ajax_referer('kvt_nonce');
-        $id = isset($_POST['id']) ? intval($_POST['id']) : 0;
-        if (!$id) wp_send_json_error(['msg'=>'Invalid'], 400);
-        delete_post_meta($id, 'kvt_notes');
-        delete_post_meta($id, 'notes');
         wp_send_json_success(['ok'=>true]);
     }
 
@@ -1654,9 +1635,17 @@ JS;
                 ['key'=>'kvt_first_name','value'=>$search,'compare'=>'LIKE'],
                 ['key'=>'kvt_last_name', 'value'=>$search,'compare'=>'LIKE'],
                 ['key'=>'kvt_email',     'value'=>$search,'compare'=>'LIKE'],
+                ['key'=>'kvt_phone',     'value'=>$search,'compare'=>'LIKE'],
+                ['key'=>'kvt_country',   'value'=>$search,'compare'=>'LIKE'],
+                ['key'=>'kvt_city',      'value'=>$search,'compare'=>'LIKE'],
+                ['key'=>'kvt_tags',      'value'=>$search,'compare'=>'LIKE'],
                 ['key'=>'first_name','value'=>$search,'compare'=>'LIKE'],
                 ['key'=>'last_name', 'value'=>$search,'compare'=>'LIKE'],
                 ['key'=>'email',     'value'=>$search,'compare'=>'LIKE'],
+                ['key'=>'phone',     'value'=>$search,'compare'=>'LIKE'],
+                ['key'=>'country',   'value'=>$search,'compare'=>'LIKE'],
+                ['key'=>'city',      'value'=>$search,'compare'=>'LIKE'],
+                ['key'=>'tags',      'value'=>$search,'compare'=>'LIKE'],
             ];
             $args['s'] = $search;
         }
@@ -1677,6 +1666,7 @@ JS;
                     'city'        => $this->meta_get_compat($p->ID,'kvt_city',['city']),
                     'cv_url'      => $this->meta_get_compat($p->ID,'kvt_cv_url',['cv_url']),
                     'cv_uploaded' => $this->fmt_date_ddmmyyyy($this->meta_get_compat($p->ID,'kvt_cv_uploaded',['cv_uploaded'])),
+                    'tags'        => $this->meta_get_compat($p->ID,'kvt_tags',['tags']),
                     'notes'       => $notes_raw,
                     'notes_count' => $this->count_notes($notes_raw),
                 ],


### PR DESCRIPTION
## Summary
- Show all candidate tags as smaller, non-clickable buttons in profile editor with guidance to separate by commas
- Display tags in candidate base modal instead of email and remove dedicated note deletion
- Expand candidate search to include tags, phone, country and city across board and base views

## Testing
- `php -l Pipeline`

------
https://chatgpt.com/codex/tasks/task_e_68b0d9830218832abbdaeb2cf3dfdd36