### PR TITLE
Expose contact info and add Base filters

### DIFF
--- a/Pipeline
+++ b/Pipeline
@@ -509,7 +509,9 @@ cv_uploaded|Fecha de subida");
                 'id'          => $t->term_id,
                 'name'        => $t->name,
                 'client_id'   => $cid ?: 0,
-                'description' => $t->description,
+                'description' => wp_strip_all_tags($t->description),
+                'contact_name'  => get_term_meta($t->term_id, 'contact_name', true),
+                'contact_email' => get_term_meta($t->term_id, 'contact_email', true),
             ];
         }
         return $out;
@@ -528,6 +530,16 @@ cv_uploaded|Fecha de subida");
         return $cnt;
     }
 
+    private function get_unique_meta_values($keys) {
+        global $wpdb;
+        $keys = array_map('esc_sql', (array) $keys);
+        $in   = "'" . implode("','", $keys) . "'";
+        $vals = $wpdb->get_col("SELECT DISTINCT meta_value FROM {$wpdb->postmeta} WHERE meta_key IN ($in) AND meta_value <> ''");
+        $vals = array_filter(array_map('trim', (array) $vals));
+        sort($vals);
+        return $vals;
+    }
+
     /* Shortcode */
     public function shortcode($atts = []) {
         if (!is_user_logged_in() || !current_user_can('edit_posts')) {
@@ -543,8 +555,11 @@ cv_uploaded|Fecha de subida");
                 'contact_name'  => get_term_meta($t->term_id, 'contact_name', true),
                 'contact_email' => get_term_meta($t->term_id, 'contact_email', true),
                 'contact_phone' => get_term_meta($t->term_id, 'contact_phone', true),
+                'description'   => wp_strip_all_tags($t->description),
             ];
         }, $clients);
+        $countries = $this->get_unique_meta_values(['kvt_country','country']);
+        $cities    = $this->get_unique_meta_values(['kvt_city','city']);
 
         ob_start(); ?>
         <div class="kvt-wrapper">
@@ -624,6 +639,20 @@ cv_uploaded|Fecha de subida");
                     <option value="">— Ninguno —</option>
                     <?php foreach ($processes as $t): ?>
                       <option value="<?php echo esc_attr($t->term_id); ?>"><?php echo esc_html($t->name); ?></option>
+                    <?php endforeach; ?>
+                  </select>
+                </label>
+                <label>País
+                  <select id="kvt_modal_country" multiple size="4">
+                    <?php foreach ($countries as $co): ?>
+                      <option value="<?php echo esc_attr($co); ?>"><?php echo esc_html($co); ?></option>
+                    <?php endforeach; ?>
+                  </select>
+                </label>
+                <label>Ciudad
+                  <select id="kvt_modal_city" multiple size="4">
+                    <?php foreach ($cities as $ci): ?>
+                      <option value="<?php echo esc_attr($ci); ?>"><?php echo esc_html($ci); ?></option>
                     <?php endforeach; ?>
                   </select>
                 </label>
@@ -721,6 +750,9 @@ cv_uploaded|Fecha de subida");
                     <option value="<?php echo esc_attr($t->term_id); ?>"><?php echo esc_html($t->name); ?></option>
                   <?php endforeach; ?>
                 </select>
+                <input type="text" id="kvt_process_contact_new" placeholder="Persona de contacto">
+                <input type="email" id="kvt_process_email_new" placeholder="Email">
+                <textarea id="kvt_process_desc_new" placeholder="Descripción"></textarea>
                 <button type="button" class="kvt-btn" id="kvt_process_submit">Crear</button>
               </div>
             </div>
@@ -856,6 +888,8 @@ document.addEventListener('DOMContentLoaded', function(){
   const modalList  = el('#kvt_modal_list', modal);
   const modalCli   = el('#kvt_modal_client', modal);
   const modalProc  = el('#kvt_modal_process', modal);
+  const modalCountry= el('#kvt_modal_country', modal);
+  const modalCity   = el('#kvt_modal_city', modal);
   const modalPrev  = el('#kvt_modal_prev', modal);
   const modalNext  = el('#kvt_modal_next', modal);
   const modalPage  = el('#kvt_modal_pageinfo', modal);
@@ -869,6 +903,8 @@ document.addEventListener('DOMContentLoaded', function(){
     filterModalProcessOptions();
     if (selProcess && selProcess.value) modalProc.value = selProcess.value;
     modalSearch.value = '';
+    if(modalCountry) Array.from(modalCountry.options).forEach(o=>o.selected=false);
+    if(modalCity) Array.from(modalCity.options).forEach(o=>o.selected=false);
     listProfiles(1);
   }
   function closeModal(){ modal.style.display = 'none'; }
@@ -1211,6 +1247,7 @@ document.addEventListener('DOMContentLoaded', function(){
         clientDet = 'Contacto: '+(c.contact_name||'');
         if(c.contact_email) clientDet += ', '+c.contact_email;
         if(c.contact_phone) clientDet += ', '+c.contact_phone;
+        if(c.description) clientDet += '<br>Descripción: '+c.description;
       }
       clientDet += ' <a href="'+selInfo.dataset.clientBase+cid+'" target="_blank">Editar</a>';
     }
@@ -1218,7 +1255,13 @@ document.addEventListener('DOMContentLoaded', function(){
     let procDet='';
     if(pid && Array.isArray(window.KVT_PROCESS_MAP)){
       const p = window.KVT_PROCESS_MAP.find(x=>String(x.id)===pid);
-      if(p){ procDet = 'Descripción: '+(p.description||''); }
+      if(p){
+        if(p.contact_name || p.contact_email){
+          procDet = 'Contacto: '+(p.contact_name||'');
+          if(p.contact_email) procDet += ', '+p.contact_email;
+        }
+        if(p.description){ procDet += (procDet?'<br>':'')+'Descripción: '+p.description; }
+      }
       procDet += ' <a href="'+selInfo.dataset.processBase+pid+'" target="_blank">Editar</a>';
     }
     selProcessInfo.innerHTML = procDet;
@@ -1257,6 +1300,10 @@ document.addEventListener('DOMContentLoaded', function(){
     params.set('_ajax_nonce', KVT_NONCE);
     params.set('page', currentPage);
     params.set('q', modalSearch.value || '');
+    const cvals = modalCountry ? Array.from(modalCountry.selectedOptions).map(o=>o.value).join(',') : '';
+    const cityVals = modalCity ? Array.from(modalCity.selectedOptions).map(o=>o.value).join(',') : '';
+    params.set('countries', cvals);
+    params.set('cities', cityVals);
     fetch(KVT_AJAX,{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:params.toString()})
       .then(r=>r.json())
       .then(j=>{
@@ -1319,6 +1366,8 @@ document.addEventListener('DOMContentLoaded', function(){
   }
   modalPrev && modalPrev.addEventListener('click', ()=>{ if(currentPage>1) listProfiles(currentPage-1); });
   modalNext && modalNext.addEventListener('click', ()=>{ listProfiles(currentPage+1); });
+  modalCountry && modalCountry.addEventListener('change', ()=>{ listProfiles(1); });
+  modalCity && modalCity.addEventListener('change', ()=>{ listProfiles(1); });
   let mto=null;
   modalSearch && modalSearch.addEventListener('input', ()=>{ clearTimeout(mto); mto=setTimeout(()=>listProfiles(1), 300); });
   btnAdd && btnAdd.addEventListener('click', openModal);
@@ -1408,8 +1457,18 @@ document.addEventListener('DOMContentLoaded', function(){
     const pclose = el('#kvt_new_process_close');
     const pname  = el('#kvt_process_name_new');
     const pcli   = el('#kvt_process_client_new');
-    const psubmit= el('#kvt_process_submit');
-    function openPModal(){ pname.value=''; pmodal.style.display='flex'; }
+    const pcontact = el('#kvt_process_contact_new');
+    const pemail   = el('#kvt_process_email_new');
+    const pdesc    = el('#kvt_process_desc_new');
+    const psubmit  = el('#kvt_process_submit');
+    function openPModal(){
+      pname.value='';
+      pcli.value='';
+      if(pcontact) pcontact.value='';
+      if(pemail) pemail.value='';
+      if(pdesc) pdesc.value='';
+      pmodal.style.display='flex';
+    }
     function closePModal(){ pmodal.style.display='none'; }
     pclose && pclose.addEventListener('click', closePModal);
     pmodal && pmodal.addEventListener('click', e=>{ if(e.target===pmodal) closePModal(); });
@@ -1419,6 +1478,9 @@ document.addEventListener('DOMContentLoaded', function(){
       params.set('_ajax_nonce', KVT_NONCE);
       params.set('name', pname.value||'');
       params.set('client_id', pcli.value||'');
+      if(pcontact) params.set('contact_name', pcontact.value||'');
+      if(pemail) params.set('contact_email', pemail.value||'');
+      if(pdesc) params.set('description', pdesc.value||'');
       fetch(KVT_AJAX,{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:params.toString()})
         .then(r=>r.json()).then(j=>{
           if(!j.success) return alert(j.data && j.data.msg ? j.data.msg : 'No se pudo crear.');
@@ -1681,6 +1743,8 @@ JS;
 
         $page   = isset($_POST['page']) ? max(1, intval($_POST['page'])) : 1;
         $search = isset($_POST['q']) ? sanitize_text_field(trim($_POST['q'])) : '';
+        $countries = isset($_POST['countries']) && $_POST['countries'] !== '' ? array_filter(array_map('sanitize_text_field', explode(',', $_POST['countries']))) : [];
+        $cities    = isset($_POST['cities']) && $_POST['cities'] !== '' ? array_filter(array_map('sanitize_text_field', explode(',', $_POST['cities']))) : [];
 
         // Return all candidates so modal shows complete list
         $args = [
@@ -1689,21 +1753,46 @@ JS;
             'posts_per_page' => -1,
             'paged'          => $page,
         ];
+
+        $meta_query = ['relation' => 'AND'];
+
+        if (!empty($countries)) {
+            $meta_query[] = [
+                'relation' => 'OR',
+                ['key'=>'kvt_country','value'=>$countries,'compare'=>'IN'],
+                ['key'=>'country','value'=>$countries,'compare'=>'IN'],
+            ];
+        }
+
+        if (!empty($cities)) {
+            $meta_query[] = [
+                'relation' => 'OR',
+                ['key'=>'kvt_city','value'=>$cities,'compare'=>'IN'],
+                ['key'=>'city','value'=>$cities,'compare'=>'IN'],
+            ];
+        }
+
         if ($search !== '') {
-            $args['meta_query'] = [
+            $meta_query[] = [
                 'relation' => 'OR',
                 ['key'=>'kvt_first_name','value'=>$search,'compare'=>'LIKE'],
                 ['key'=>'kvt_last_name', 'value'=>$search,'compare'=>'LIKE'],
                 ['key'=>'kvt_email',     'value'=>$search,'compare'=>'LIKE'],
                 ['key'=>'kvt_country',   'value'=>$search,'compare'=>'LIKE'],
                 ['key'=>'kvt_city',      'value'=>$search,'compare'=>'LIKE'],
+                ['key'=>'kvt_tags',      'value'=>$search,'compare'=>'LIKE'],
                 ['key'=>'first_name','value'=>$search,'compare'=>'LIKE'],
                 ['key'=>'last_name', 'value'=>$search,'compare'=>'LIKE'],
                 ['key'=>'email',     'value'=>$search,'compare'=>'LIKE'],
                 ['key'=>'country',   'value'=>$search,'compare'=>'LIKE'],
                 ['key'=>'city',      'value'=>$search,'compare'=>'LIKE'],
+                ['key'=>'tags',      'value'=>$search,'compare'=>'LIKE'],
             ];
             $args['s'] = $search;
+        }
+
+        if (count($meta_query) > 1) {
+            $args['meta_query'] = $meta_query;
         }
 
         $q = new WP_Query($args);
@@ -1842,17 +1931,22 @@ JS;
       public function ajax_create_process() {
           check_ajax_referer('kvt_nonce');
 
-          $name = isset($_POST['name']) ? sanitize_text_field($_POST['name']) : '';
-          $client_id = isset($_POST['client_id']) ? intval($_POST['client_id']) : 0;
-          if ($name === '') wp_send_json_error(['msg'=>'Nombre requerido'],400);
+        $name = isset($_POST['name']) ? sanitize_text_field($_POST['name']) : '';
+        $client_id = isset($_POST['client_id']) ? intval($_POST['client_id']) : 0;
+        $contact_name  = isset($_POST['contact_name']) ? sanitize_text_field($_POST['contact_name']) : '';
+        $contact_email = isset($_POST['contact_email']) ? sanitize_email($_POST['contact_email']) : '';
+        $desc = isset($_POST['description']) ? sanitize_textarea_field($_POST['description']) : '';
+        if ($name === '') wp_send_json_error(['msg'=>'Nombre requerido'],400);
 
-          $term = wp_insert_term($name, self::TAX_PROCESS);
-          if (is_wp_error($term)) wp_send_json_error(['msg'=>$term->get_error_message()],500);
-          $tid = (int) $term['term_id'];
-          if ($client_id) update_term_meta($tid, 'kvt_process_client', $client_id);
+        $term = wp_insert_term($name, self::TAX_PROCESS, ['description'=>$desc]);
+        if (is_wp_error($term)) wp_send_json_error(['msg'=>$term->get_error_message()],500);
+        $tid = (int) $term['term_id'];
+        if ($client_id) update_term_meta($tid, 'kvt_process_client', $client_id);
+        if ($contact_name)  update_term_meta($tid, 'contact_name', $contact_name);
+        if ($contact_email) update_term_meta($tid, 'contact_email', $contact_email);
 
-          wp_send_json_success(['id'=>$tid]);
-      }
+        wp_send_json_success(['id'=>$tid]);
+    }
 
       public function ajax_assign_candidate() {
           check_ajax_referer('kvt_nonce');


### PR DESCRIPTION
## Summary
- display client and process contact details and descriptions when viewing more information on the board
- allow creating processes with contact data and description from the board
- filter candidates in Base tab by multiple countries/cities and search within tags

## Testing
- `php -l Pipeline`


------
https://chatgpt.com/codex/tasks/task_e_68b0ef5cccc0832aadd15425662ccce7