### PR TITLE
Add info pop-up and OpenAI CV search

### DIFF
--- a/Pipeline
+++ b/Pipeline
@@ -15,6 +15,7 @@ class Kovacic_Pipeline_Visualizer {
     const OPT_GROUP     = 'kvt_options';
     const OPT_STATUSES  = 'kvt_statuses';
     const OPT_COLUMNS   = 'kvt_columns';
+    const OPT_OPENAI_KEY= 'kvt_openai_key';
 
     public function __construct() {
         add_action('init',                       [$this, 'register_types']);
@@ -81,6 +82,8 @@ class Kovacic_Pipeline_Visualizer {
         add_action('wp_ajax_nopriv_kvt_assign_candidate',[$this, 'ajax_assign_candidate']);
         add_action('wp_ajax_kvt_unassign_candidate',   [$this, 'ajax_unassign_candidate']);
         add_action('wp_ajax_nopriv_kvt_unassign_candidate',[$this, 'ajax_unassign_candidate']);
+        add_action('wp_ajax_kvt_ai_search',            [$this, 'ajax_ai_search']);
+        add_action('wp_ajax_nopriv_kvt_ai_search',     [$this, 'ajax_ai_search']);
 
         // Export
         add_action('admin_post_kvt_export',          [$this, 'handle_export']);
@@ -139,6 +142,7 @@ cv_uploaded|Fecha de subida");
     public function register_settings() {
         register_setting(self::OPT_GROUP, self::OPT_STATUSES);
         register_setting(self::OPT_GROUP, self::OPT_COLUMNS);
+        register_setting(self::OPT_GROUP, self::OPT_OPENAI_KEY);
     }
     public function admin_menu() {
         add_options_page('Kovacic Pipeline','Kovacic Pipeline','manage_options','kvt-settings',[$this,'settings_page']);
@@ -146,6 +150,7 @@ cv_uploaded|Fecha de subida");
     public function settings_page() {
         $statuses = get_option(self::OPT_STATUSES, "");
         $columns  = get_option(self::OPT_COLUMNS, "");
+        $openai   = get_option(self::OPT_OPENAI_KEY, "");
         ?>
         <div class="wrap">
             <h1>Kovacic Pipeline — Ajustes</h1>
@@ -157,6 +162,13 @@ cv_uploaded|Fecha de subida");
                         <td>
                             <textarea name="<?php echo self::OPT_STATUSES; ?>" id="<?php echo self::OPT_STATUSES; ?>" rows="8" class="large-text" placeholder="Un estado por línea, de izquierda a derecha en el tablero"><?php echo esc_textarea($statuses); ?></textarea>
                             <p class="description">Ejemplo (uno por línea): Identified, Contacted, Interviewed, Offer, Declined</p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><label for="<?php echo self::OPT_OPENAI_KEY; ?>">OpenAI API Key</label></th>
+                        <td>
+                            <input type="text" name="<?php echo self::OPT_OPENAI_KEY; ?>" id="<?php echo self::OPT_OPENAI_KEY; ?>" class="regular-text" value="<?php echo esc_attr($openai); ?>">
+                            <p class="description">Clave utilizada para las búsquedas avanzadas.</p>
                         </td>
                     </tr>
                     <tr>
@@ -623,6 +635,16 @@ cv_uploaded|Fecha de subida");
                 </table>
             </div>
         </div>
+        <!-- Info Modal -->
+        <div class="kvt-modal" id="kvt_info_modal" style="display:none;">
+          <div class="kvt-modal-content">
+            <div class="kvt-modal-header">
+              <h3>Información</h3>
+              <button type="button" class="kvt-modal-close" id="kvt_info_close" aria-label="Cerrar"><span class="dashicons dashicons-no-alt"></span></button>
+            </div>
+            <div class="kvt-modal-body" id="kvt_info_body"></div>
+          </div>
+        </div>
 
         <!-- Modal Base -->
         <div class="kvt-modal" id="kvt_modal" style="display:none;">
@@ -636,6 +658,7 @@ cv_uploaded|Fecha de subida");
                 <button type="button" class="kvt-tab active" data-target="candidates">Candidatos</button>
                 <button type="button" class="kvt-tab" data-target="clients">Clientes</button>
                 <button type="button" class="kvt-tab" data-target="processes">Procesos</button>
+                <button type="button" class="kvt-tab" data-target="ai">AI Search</button>
               </div>
               <div class="kvt-new" id="kvt_new_container">
                 <button type="button" class="kvt-btn" id="kvt_new_btn">Nuevo</button>
@@ -688,6 +711,13 @@ cv_uploaded|Fecha de subida");
               </div>
               <div id="kvt_tab_processes" class="kvt-tab-panel">
                 <div id="kvt_processes_list" class="kvt-modal-list"></div>
+              </div>
+              <div id="kvt_tab_ai" class="kvt-tab-panel">
+                <div class="kvt-modal-controls">
+                  <textarea id="kvt_ai_input" rows="6" style="width:100%;" placeholder="Pega descripción del trabajo"></textarea>
+                  <button type="button" class="kvt-btn" id="kvt_ai_search">Buscar</button>
+                </div>
+                <div id="kvt_ai_results" class="kvt-modal-list"></div>
               </div>
             </div>
           </div>
@@ -889,11 +919,14 @@ document.addEventListener('DOMContentLoaded', function(){
     const btnAllXLS  = el('#kvt_export_all_xls');
     const exportAllForm   = el('#kvt_export_all_form');
     const exportAllFormat = el('#kvt_export_all_format');
-    const selInfo    = el('#kvt_selected_info');
-    const selToggle  = el('#kvt_selected_toggle');
-    const selDetails = el('#kvt_selected_details');
-    const selClientInfo = el('#kvt_selected_client');
-    const selProcessInfo = el('#kvt_selected_process');
+  const selInfo    = el('#kvt_selected_info');
+  const selToggle  = el('#kvt_selected_toggle');
+  const selDetails = el('#kvt_selected_details');
+  const selClientInfo = el('#kvt_selected_client');
+  const selProcessInfo = el('#kvt_selected_process');
+  const infoModal = el('#kvt_info_modal');
+  const infoClose = el('#kvt_info_close');
+  const infoBody  = el('#kvt_info_body');
 
   const modal      = el('#kvt_modal');
   const modalClose = el('.kvt-modal-close', modal);
@@ -908,8 +941,12 @@ document.addEventListener('DOMContentLoaded', function(){
   const tabCandidates = el('#kvt_tab_candidates', modal);
   const tabClients = el('#kvt_tab_clients', modal);
   const tabProcesses = el('#kvt_tab_processes', modal);
+  const tabAI = el('#kvt_tab_ai', modal);
   const clientsList = el('#kvt_clients_list', modal);
   const processesList = el('#kvt_processes_list', modal);
+  const aiInput = el('#kvt_ai_input', modal);
+  const aiBtn = el('#kvt_ai_search', modal);
+  const aiResults = el('#kvt_ai_results', modal);
 
   function getClientById(id){
     if(!Array.isArray(window.KVT_CLIENT_MAP)) return null;
@@ -928,6 +965,7 @@ document.addEventListener('DOMContentLoaded', function(){
     if(tabCandidates) tabCandidates.classList.toggle('active', target==='candidates');
     if(tabClients) tabClients.classList.toggle('active', target==='clients');
     if(tabProcesses) tabProcesses.classList.toggle('active', target==='processes');
+    if(tabAI) tabAI.classList.toggle('active', target==='ai');
     tabs.forEach(b=>b.classList.toggle('active', b.dataset.target===target));
     if(target==='clients') listClients();
     if(target==='processes') listProcesses();
@@ -1305,9 +1343,24 @@ document.addEventListener('DOMContentLoaded', function(){
   btnXLS && btnXLS.addEventListener('click', ()=>{ el('#kvt_export_format').value='xls'; syncExportHidden(); exportForm.submit(); });
   btnAllCSV && btnAllCSV.addEventListener('click', ()=>{ exportAllFormat.value='csv'; exportAllForm && exportAllForm.submit(); });
   btnAllXLS && btnAllXLS.addEventListener('click', ()=>{ exportAllFormat.value='xls'; exportAllForm && exportAllForm.submit(); });
-
+  infoClose && infoClose.addEventListener('click', ()=>{ infoModal.style.display='none'; });
+  infoModal && infoModal.addEventListener('click', e=>{ if(e.target===infoModal) infoModal.style.display='none'; });
   selToggle && selToggle.addEventListener('click', ()=>{
-    selDetails.style.display = selDetails.style.display==='block' ? 'none' : 'block';
+    infoBody.innerHTML = selDetails.innerHTML;
+    infoModal.style.display='flex';
+  });
+  aiBtn && aiBtn.addEventListener('click', ()=>{
+    const desc = (aiInput.value||'').trim();
+    if(!desc) return;
+    const params = new URLSearchParams();
+    params.set('action','kvt_ai_search');
+    params.set('_ajax_nonce', KVT_NONCE);
+    params.set('description', desc);
+    fetch(KVT_AJAX,{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:params.toString()})
+      .then(r=>r.json()).then(j=>{
+        if(!j.success){ alert('No se pudo buscar.'); return; }
+        aiResults.innerHTML = Array.isArray(j.data.items)?j.data.items.map(it=>'<div class="kvt-card-mini"><h4>'+esc(it.name||'')+'</h4><p>'+esc(it.summary||'')+'</p></div>').join('') : '';
+      });
   });
 
   btnToggle && btnToggle.addEventListener('click', ()=>{
@@ -2218,6 +2271,87 @@ JS;
         update_term_meta($id, 'contact_email', $contact_email);
 
         wp_send_json_success(['id'=>$id]);
+    }
+
+    public function ajax_ai_search() {
+        check_ajax_referer('kvt_nonce');
+
+        $desc = isset($_POST['description']) ? sanitize_textarea_field($_POST['description']) : '';
+        if (!$desc) wp_send_json_error(['msg' => 'Descripción vacía'], 400);
+
+        $key = get_option(self::OPT_OPENAI_KEY, '');
+        if (!$key) wp_send_json_error(['msg' => 'Falta la clave'], 400);
+
+        $candidates = get_posts(['post_type' => self::CPT, 'posts_per_page' => -1]);
+        $items = [];
+        foreach ($candidates as $c) {
+            $cv_text = $this->get_candidate_cv_text($c->ID);
+            if (!$cv_text) continue;
+            $summary = $this->openai_match_summary($key, $desc, $cv_text);
+            if ($summary) {
+                $fname = $this->meta_get_compat($c->ID, 'kvt_first_name', ['first_name']);
+                $lname = $this->meta_get_compat($c->ID, 'kvt_last_name', ['last_name']);
+                $name  = trim($fname . ' ' . $lname);
+                if (!$name) $name = $c->post_title;
+                $items[] = ['id' => $c->ID, 'name' => $name, 'summary' => $summary];
+            }
+        }
+
+        wp_send_json_success(['items' => $items]);
+    }
+
+    private function get_candidate_cv_text($post_id) {
+        $cv_url = $this->meta_get_compat($post_id, 'kvt_cv_url', ['cv_url']);
+        if (!$cv_url) return '';
+        $response = wp_remote_get($cv_url);
+        if (is_wp_error($response)) return '';
+        $body = wp_remote_retrieve_body($response);
+        $file = wp_tempnam($cv_url);
+        if (!$file) return '';
+        file_put_contents($file, $body);
+        $type = wp_check_filetype($cv_url);
+        $ext = isset($type['ext']) ? strtolower($type['ext']) : '';
+        $text = '';
+        if ($ext === 'pdf') {
+            if (function_exists('shell_exec')) {
+                $text = shell_exec('pdftotext ' . escapeshellarg($file) . ' -');
+            }
+        } elseif ($ext === 'docx') {
+            if (class_exists('ZipArchive')) {
+                $zip = new \ZipArchive();
+                if ($zip->open($file) === true) {
+                    $xml = $zip->getFromName('word/document.xml');
+                    if ($xml) $text = strip_tags($xml);
+                    $zip->close();
+                }
+            }
+        } else {
+            $text = $body;
+        }
+        @unlink($file);
+        return wp_strip_all_tags($text);
+    }
+
+    private function openai_match_summary($key, $desc, $cv_text) {
+        $req = [
+            'model' => 'gpt-4o-mini',
+            'messages' => [
+                ['role' => 'system', 'content' => 'Eres un asistente de reclutamiento.'],
+                ['role' => 'user', 'content' => "Descripción del trabajo:\n$desc\nCV del candidato:\n$cv_text\nResume en tres frases por qué este candidato encaja o no."],
+            ],
+            'max_tokens' => 150,
+        ];
+        $response = wp_remote_post('https://api.openai.com/v1/chat/completions', [
+            'headers' => [
+                'Authorization' => 'Bearer ' . $key,
+                'Content-Type'  => 'application/json',
+            ],
+            'body' => wp_json_encode($req),
+            'timeout' => 60,
+        ]);
+        if (is_wp_error($response)) return '';
+        $body = json_decode(wp_remote_retrieve_body($response), true);
+        return isset($body['choices'][0]['message']['content']) ? trim($body['choices'][0]['message']['content']) : '';
     }
 
       public function ajax_assign_candidate() {


### PR DESCRIPTION
## Summary
- show selected client and process details in a modal pop-up on the board
- add AI Search tab in Base to match job descriptions with candidate CVs using OpenAI
- allow storing OpenAI API key in plugin settings

## Testing
- `php -l Pipeline`


------
https://chatgpt.com/codex/tasks/task_e_68b10a409310832aaf5d4ec5b54a498f